### PR TITLE
Make module installable in ProcessWire 3.x

### DIFF
--- a/Webmention/GregorMorrill/Webmention/WireHttp.php
+++ b/Webmention/GregorMorrill/Webmention/WireHttp.php
@@ -2,6 +2,9 @@
 
 namespace GregorMorrill\ProcessWireShim;
 
+use \ProcessWire\WireHttp as PwWireHttp;
+
+
 /**
  * This is an extension of the WireHttp class to add support for multiple
  * response headers of the same type. It serves as a shim until ProcessWire core is updaed to
@@ -12,7 +15,7 @@ namespace GregorMorrill\ProcessWireShim;
 // error_reporting(E_ALL);
 // ini_set('display_errors', TRUE);
 
-class WireHttp extends \WireHttp
+class WireHttp extends PwWireHttp
 {
 
 	/**


### PR DESCRIPTION
Hi Gregor,

I'm still in the process of checking if all the needed functionality works in PW 3.X, but this fix at least prevents the error message while installing 1.1.3 @ PW3.

Also I am not completely certain regarding master/dev (they seem not to be in sync; each of them have exclusive commits), so I based this fix on master and pointing this PW towards master.

Hoping this is an improvement at all, otherwise, let me know.

Best,
marcus